### PR TITLE
Hash user metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -433,6 +433,7 @@ with st.form(key="form"):
             selected_dataset,
             selected_config,
             selected_split,
+            selected_metrics,
         )
         print("INFO -- Selected models after filter:", selected_models)
 


### PR DESCRIPTION
With the inclusion of user-selected metrics in the dataset cards of model predictions (https://github.com/huggingface/autonlp-backend/pull/593), we can now include this information in the hash and partially address the issue raised by @TristanThrush : https://huggingface.co/spaces/autoevaluate/model-evaluator/discussions/1

This approach now enables the following jobs to be treated as distinct:

* Evaluation job with no user metrics
* Evaluation jobs with 1 or more metrics

The only edge case I see is when:

* user A selects metric M1
* user B selects metric M2
* user C selects metrics [M1, M2]

The hashing will treat all three jobs as distinct, so some duplicity occurs with user C. Will handle this at a later point in time