### PR TITLE
fix for double dataset select bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,10 +141,13 @@ st.markdown(
 
 all_datasets = [d.id for d in list_datasets()]
 query_params = st.experimental_get_query_params()
+if "first_query_params" not in st.session_state:
+    st.session_state.first_query_params = query_params
+first_query_params = st.session_state.first_query_params
 default_dataset = all_datasets[0]
-if "dataset" in query_params:
-    if len(query_params["dataset"]) > 0 and query_params["dataset"][0] in all_datasets:
-        default_dataset = query_params["dataset"][0]
+if "dataset" in first_query_params:
+    if len(first_query_params["dataset"]) > 0 and first_query_params["dataset"][0] in all_datasets:
+        default_dataset = first_query_params["dataset"][0]
 
 selected_dataset = st.selectbox(
     "Select a dataset",


### PR DESCRIPTION
This PR fixes the bug that forces users to select a dataset twice to navigate to it. The PR uses streamlit's session state to set the default dataset only when someone goes to a model-evaluator url. Redundantly setting the default dataset is the cause of the "double select" bug.