### PR TITLE
Enable any summarization model to be evaluated on any dataset

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -79,6 +79,13 @@ def get_compatible_models(task: str, dataset_ids: List[str]) -> List[str]:
         A list of model IDs, sorted alphabetically.
     """
     compatible_models = []
+    # Allow any summarization model to be used for summarization tasks
+    if task == "summarization":
+        model_filter = ModelFilter(
+            task=AUTOTRAIN_TASK_TO_HUB_TASK[task],
+            library=["transformers", "pytorch"],
+        )
+        compatible_models.extend(HfApi().list_models(filter=model_filter))
     # Include models trained on SQuAD datasets, since these can be evaluated on
     # other SQuAD-like datasets
     if task == "extractive_question_answering":


### PR DESCRIPTION
Text summarization models can in principle be evaluated on any dataset that has `(text, summary)` columns, so this PR relaxes the constraint of compatible models accordingly.

Example Hub PR: https://huggingface.co/google/pegasus-cnn_dailymail/discussions/1