### PR TITLE
Store dataset ID in AutoTrain project name

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 import os
-import uuid
 from pathlib import Path
 
 import pandas as pd
@@ -13,6 +12,7 @@ from evaluation import filter_evaluated_models
 from utils import (
     AUTOTRAIN_TASK_TO_HUB_TASK,
     commit_evaluation_log,
+    create_autotrain_project_name,
     format_col_mapping,
     get_compatible_models,
     get_dataset_card_url,
@@ -459,10 +459,9 @@ with st.form(key="form"):
             )
             print("INFO -- Selected models after filter:", selected_models)
             if len(selected_models) > 0:
-                project_id = str(uuid.uuid4())[:8]
                 project_payload = {
                     "username": AUTOTRAIN_USERNAME,
-                    "proj_name": f"eval-project-{project_id}",
+                    "proj_name": create_autotrain_project_name(selected_dataset),
                     "task": TASK_TO_ID[selected_task],
                     "config": {
                         "language": AUTOTRAIN_TASK_TO_LANG[selected_task]

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import uuid
 from typing import Dict, List, Union
 
 import jsonlines
@@ -180,3 +181,12 @@ def get_dataset_card_url(dataset_id: str) -> str:
         return f"https://huggingface.co/datasets/{dataset_id}/edit/main/README.md"
     else:
         return f"https://github.com/huggingface/datasets/edit/master/datasets/{dataset_id}/README.md"
+
+
+def create_autotrain_project_name(dataset_id: str) -> str:
+    """Creates an AutoTrain project name for the given dataset ID."""
+    # Project names cannot have "/", so we need to format community datasets accordingly
+    dataset_id_formatted = dataset_id.replace("/", "--")
+    # Project names need to be unique, so we append a random string to guarantee this
+    project_id = str(uuid.uuid4())[:8]
+    return f"eval-project-{dataset_id_formatted}-{project_id}"


### PR DESCRIPTION
To help with debugging failed jobs, it is handy to know which dataset is associated with a given project in AutoTrain. 

This PR adds the dataset ID to the project name as shown in the screenshot below:

<img width="1287" alt="Screen Shot 2022-07-06 at 12 20 39" src="https://user-images.githubusercontent.com/26859204/177528921-78f2b1c9-fd06-494f-8cdb-39aac7c20e8d.png">
