### PR TITLE
Add dataset config to AutoTrain project name

### DIFF
--- a/app.py
+++ b/app.py
@@ -525,7 +525,7 @@ with st.form(key="form"):
             if len(selected_models) > 0:
                 project_payload = {
                     "username": AUTOTRAIN_USERNAME,
-                    "proj_name": create_autotrain_project_name(selected_dataset),
+                    "proj_name": create_autotrain_project_name(selected_dataset, selected_config),
                     "task": TASK_TO_ID[selected_task],
                     "config": {
                         "language": AUTOTRAIN_TASK_TO_LANG[selected_task]

--- a/utils.py
+++ b/utils.py
@@ -191,13 +191,13 @@ def get_dataset_card_url(dataset_id: str) -> str:
         return f"https://github.com/huggingface/datasets/edit/master/datasets/{dataset_id}/README.md"
 
 
-def create_autotrain_project_name(dataset_id: str) -> str:
+def create_autotrain_project_name(dataset_id: str, dataset_config: str) -> str:
     """Creates an AutoTrain project name for the given dataset ID."""
     # Project names cannot have "/", so we need to format community datasets accordingly
     dataset_id_formatted = dataset_id.replace("/", "__")
     # Project names need to be unique, so we append a random string to guarantee this
-    project_id = str(uuid.uuid4())[:8]
-    return f"eval-project-{dataset_id_formatted}-{project_id}"
+    project_id = str(uuid.uuid4())[:6]
+    return f"eval-{dataset_id_formatted}-{dataset_config}-{project_id}"
 
 
 def get_config_metadata(config: str, metadata: List[Dict] = None) -> Union[Dict, None]:


### PR DESCRIPTION
This PR adds the dataset config name to AutoTrain project names to enable a better debugging experience.

With this change it is easier to figure out why a project had a particular problem on a config. This is especially useful for datasets like GLUE that have many configs

![Screen Shot 2022-08-29 at 14 27 39](https://user-images.githubusercontent.com/26859204/187200876-7a9bab89-1793-4ad5-b649-4f45b9705e0b.png)
